### PR TITLE
Add Config type and NewClient func

### DIFF
--- a/advisories.go
+++ b/advisories.go
@@ -2,12 +2,22 @@ package bart
 
 // AdvisoriesAPI is a namespace for advisory information requests to routes at
 // /bsa.aspx. See official docs at https://api.bart.gov/docs/bsa/.
-type AdvisoriesAPI struct{}
+type AdvisoriesAPI struct {
+	conf *Config
+}
+
+func (a *AdvisoriesAPI) clientConf() *Config {
+	if a != nil && a.conf != nil {
+		return a.conf
+	}
+	return defaultClientConf
+}
 
 // RequestBSA requests current advisory information. See official docs at
 // https://api.bart.gov/docs/bsa/bsa.aspx.
 func (a *AdvisoriesAPI) RequestBSA() (res AdvisoriesBSAResponse, err error) {
 	err = requestAPI(
+		a,
 		"/bsa.aspx",
 		"bsa",
 		nil,
@@ -33,6 +43,7 @@ type AdvisoriesBSAResponse struct {
 // docs at https://api.bart.gov/docs/bsa/elev.aspx.
 func (a *AdvisoriesAPI) RequestElevator() (res AdvisoriesElevatorResponse, err error) {
 	err = requestAPI(
+		a,
 		"/bsa.aspx",
 		"elev",
 		nil,
@@ -60,6 +71,7 @@ type AdvisoriesElevatorResponse struct {
 // system. See official docs at: https://api.bart.gov/docs/bsa/count.aspx.
 func (a *AdvisoriesAPI) RequestTrainCount() (res AdvisoriesTrainCountResponse, err error) {
 	err = requestAPI(
+		a,
 		"/bsa.aspx",
 		"count",
 		nil,

--- a/api_test.go
+++ b/api_test.go
@@ -8,6 +8,17 @@ import (
 	"testing"
 )
 
+type stubAPI struct {
+	conf *Config
+}
+
+func (a *stubAPI) clientConf() *Config {
+	if a != nil && a.conf != nil {
+		return a.conf
+	}
+	return defaultClientConf
+}
+
 func TestRequestAPI(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		reqURL, err := url.ParseRequestURI(r.RequestURI)
@@ -30,17 +41,125 @@ func TestRequestAPI(t *testing.T) {
 			panic(err)
 		}
 	}))
-	originalBaseURL := baseURL
-	baseURL = server.URL
-	defer func() {
-		server.Close()
-		baseURL = originalBaseURL
-	}()
+	client := stubAPI{
+		conf: &Config{
+			Key:  Key,
+			HTTP: &http.Client{},
+		},
+	}
+	client.conf.baseURL = server.URL
+	defer server.Close()
 
 	var out interface{}
-	actual := requestAPI("/route.aspx", "foo", nil, &out)
+	actual := requestAPI(&client, "/route.aspx", "foo", nil, &out)
 	expectedError := "error: Invalid cmd. The cmd parameter (foo) is missing or invalid. Please correct the error and try again."
 	if actual.Error() != expectedError {
 		t.Errorf("Error formatted incorrectly. Got %q, expected %q", actual.Error(), expectedError)
+	}
+}
+
+type transporter struct{}
+
+func (tr *transporter) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func TestClient(t *testing.T) {
+	var expectedURI string
+	apiClient := NewClient(&Config{
+		Key:  "FOO-BAR",
+		HTTP: &http.Client{Transport: &transporter{}},
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		actualReqURI := r.URL.String()
+		if actualReqURI != expectedURI {
+			t.Errorf("wrong URI. Got %q, expected %q", actualReqURI, expectedURI)
+		}
+		fmt.Fprint(w, `{"root": {"uri": { "#cdata-section": "ok usa" }}}`)
+	}))
+
+	apiClient.conf.baseURL = server.URL
+	defaultClientConf.baseURL = server.URL
+	defer func() {
+		defaultClientConf.baseURL = baseURL
+		server.Close()
+	}()
+
+	tests := []struct {
+		client *Client
+		apiKey string
+	}{
+		{client: apiClient, apiKey: "FOO-BAR"},
+
+		// Previously documented examples, which used `new`, should work.
+		{client: new(Client), apiKey: Key},
+	}
+
+	for _, test := range tests {
+		client := test.client
+		key := test.apiKey
+
+		// AdvisoriesAPI
+		expectedURI = fmt.Sprintf("/bsa.aspx?cmd=bsa&json=y&key=%s", key)
+		client.RequestBSA()
+		expectedURI = fmt.Sprintf("/bsa.aspx?cmd=elev&json=y&key=%s", key)
+		client.RequestElevator()
+		expectedURI = fmt.Sprintf("/bsa.aspx?cmd=count&json=y&key=%s", key)
+		client.RequestTrainCount()
+
+		// EstimatesAPI
+		expectedURI = fmt.Sprintf("/etd.aspx?cmd=etd&dir=s&json=y&key=%s&orig=mcar&plat=4", key)
+		client.RequestETD("mcar", "4", "s")
+		expectedURI = fmt.Sprintf("/etd.aspx?cmd=etd&dir=n&json=y&key=%s&orig=civc", key)
+		client.RequestEstimate(EstimateParams{Orig: "civc", Dir: "n"})
+
+		// RoutesAPI
+		expectedURI = fmt.Sprintf("/route.aspx?cmd=routes&json=y&key=%s", key)
+		client.RequestRoutes("")
+		expectedURI = fmt.Sprintf("/route.aspx?cmd=routeinfo&json=y&key=%s&route=all", key)
+		client.RequestRoutesInfo("")
+
+		// SchedulesAPI
+		expectedURI = fmt.Sprintf("/sched.aspx?a=3&b=3&cmd=arrive&dest=cols&json=y&key=%s&l=1&orig=embr&time=6%s30pm", key, "%3A")
+		client.RequestArrivals(TripParams{
+			Orig:   "embr",
+			Dest:   "cols",
+			Time:   "6:30pm",
+			Date:   "",
+			Before: 3,
+			After:  3,
+			Legend: true,
+		})
+		expectedURI = fmt.Sprintf("/sched.aspx?cmd=scheds&json=y&key=%s", key)
+		client.RequestAvailableSchedules()
+		expectedURI = fmt.Sprintf("/sched.aspx?a=2&b=2&cmd=depart&dest=cast&json=y&key=%s&l=1&orig=sfia", key)
+		client.RequestDepartures(TripParams{
+			Orig:   "sfia",
+			Dest:   "cast",
+			Time:   "",
+			Date:   "",
+			Before: 2,
+			After:  2,
+			Legend: true,
+		})
+		expectedURI = fmt.Sprintf("/sched.aspx?cmd=holiday&json=y&key=%s", key)
+		client.RequestHolidaySchedules()
+		expectedURI = fmt.Sprintf("/sched.aspx?cmd=routesched&date=sa&json=y&key=%s&l=1&route=12", key)
+		client.RequestRouteSchedules(12, "sa", "", true)
+		expectedURI = fmt.Sprintf("/sched.aspx?cmd=special&json=y&key=%s", key)
+		client.RequestSpecialSchedules()
+		expectedURI = fmt.Sprintf("/sched.aspx?cmd=stnsched&json=y&key=%s&orig=mcar", key)
+		client.RequestStationSchedules("mcar", "")
+		expectedURI = fmt.Sprintf("/sched.aspx?cmd=stnsched&date=8%s14%s2018&json=y&key=%s&orig=glen", "%2F", "%2F", key)
+		client.RequestStationSchedules("glen", "8/14/2018")
+
+		// StationsAPI
+		expectedURI = fmt.Sprintf("/stn.aspx?cmd=stnaccess&json=y&key=%s&orig=phil", key)
+		client.RequestStationAccess("phil")
+		expectedURI = fmt.Sprintf("/stn.aspx?cmd=stninfo&json=y&key=%s&orig=mont", key)
+		client.RequestStationInfo("mont")
+		expectedURI = fmt.Sprintf("/stn.aspx?cmd=stns&json=y&key=%s", key)
+		client.RequestStations()
 	}
 }

--- a/estimates.go
+++ b/estimates.go
@@ -7,7 +7,16 @@ import (
 
 // EstimatesAPI is a namespace for real-time information requests to /etd.aspx.
 // See official docs at https://api.bart.gov/docs/etd/.
-type EstimatesAPI struct{}
+type EstimatesAPI struct {
+	conf *Config
+}
+
+func (a *EstimatesAPI) clientConf() *Config {
+	if a != nil && a.conf != nil {
+		return a.conf
+	}
+	return defaultClientConf
+}
 
 // RequestETD requests estimated departure time for specified station. The orig
 // param must be a 4-letter abbreviation for a station name. Specify plat "1",
@@ -23,6 +32,7 @@ func (a *EstimatesAPI) RequestETD(orig, plat, dir string) (res EstimatesResponse
 	}
 
 	err = requestAPI(
+		a,
 		"/etd.aspx",
 		"etd",
 		params.toURLValues(),
@@ -61,6 +71,7 @@ func (a *EstimatesAPI) RequestEstimate(p EstimateParams) (res EstimatesResponse,
 	params := p.toURLValues()
 
 	err = requestAPI(
+		a,
 		"/etd.aspx",
 		"etd",
 		params,

--- a/example_client_test.go
+++ b/example_client_test.go
@@ -1,0 +1,41 @@
+package bart_test
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/rafaelespinoza/bart-go"
+)
+
+type demo struct{}
+
+func (*demo) RoundTrip(req *http.Request) (*http.Response, error) {
+	fmt.Println(req.URL)
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func ExampleClient() {
+	var client *bart.Client
+
+	// use default settings
+	client = bart.NewClient(nil)
+
+	// or configure client settings
+	conf := &bart.Config{
+		// replace with your registered API key, optional.
+		Key: "FOO-BAR",
+
+		// configure HTTP client, optional.
+		HTTP: &http.Client{
+			Transport: &demo{},
+		},
+	}
+	client = bart.NewClient(conf)
+
+	res, err := client.RequestStations()
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Println(res)
+	}
+}

--- a/example_test.go
+++ b/example_test.go
@@ -7,26 +7,26 @@ import (
 )
 
 func ExampleAdvisoriesAPI() {
-	c := new(bart.Client)
+	client := bart.NewClient(nil)
 	var res interface{}
 	var err error
 
 	// Get current advisories.
-	res, err = c.AdvisoriesAPI.RequestBSA()
+	res, err = client.RequestBSA()
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get current elevator status.
-	res, err = c.AdvisoriesAPI.RequestElevator()
+	res, err = client.RequestElevator()
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get number of trains currently active.
-	res, err = c.AdvisoriesAPI.RequestTrainCount()
+	res, err = client.RequestTrainCount()
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -39,26 +39,26 @@ func ExampleAdvisoriesAPI() {
 }
 
 func ExampleRoutesAPI() {
-	c := new(bart.Client)
+	client := bart.NewClient(nil)
 	var res interface{}
 	var err error
 
 	// Get information on current routes.
-	res, err = c.RoutesAPI.RequestRoutes("")
+	res, err = client.RequestRoutes("")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get route information based today's schedule.
-	res, err = c.RoutesAPI.RequestRoutesInfo("")
+	res, err = client.RequestRoutesInfo("")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get route information based on specific date's schedule.
-	res, err = c.RoutesAPI.RequestRoutesInfo("1/1/2018")
+	res, err = client.RequestRoutesInfo("1/1/2018")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -71,33 +71,33 @@ func ExampleRoutesAPI() {
 }
 
 func ExampleStationsAPI() {
-	c := new(bart.Client)
+	client := bart.NewClient(nil)
 	var res interface{}
 	var err error
 
 	// Request access information on MacArthur station.
-	res, err = c.StationsAPI.RequestStationAccess("mcar")
+	res, err = client.RequestStationAccess("mcar")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Invalid station inputs will return an error.
-	res, err = c.StationsAPI.RequestStationAccess("nope")
+	res, err = client.RequestStationAccess("nope")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get detailed info on a specific station.
-	res, err = c.StationsAPI.RequestStationInfo("civc")
+	res, err = client.RequestStationInfo("civc")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get all the stations.
-	res, err = c.StationsAPI.RequestStations()
+	res, err = client.RequestStations()
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -112,33 +112,33 @@ func ExampleStationsAPI() {
 }
 
 func ExampleEstimatesAPI() {
-	c := new(bart.Client)
+	client := bart.NewClient(nil)
 	var res interface{}
 	var err error
 
 	// Get real-time estimates for all stations.
-	res, err = c.EstimatesAPI.RequestETD("ALL", "", "")
+	res, err = client.RequestETD("ALL", "", "")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get real-time estimates for a station, all platforms, directions.
-	res, err = c.EstimatesAPI.RequestETD("cast", "", "")
+	res, err = client.RequestETD("cast", "", "")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get real-time estimates for a station, specific platform, any direction.
-	res, err = c.EstimatesAPI.RequestETD("nbrk", "2", "")
+	res, err = client.RequestETD("nbrk", "2", "")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get real-time estimates for a station, any platform, specific direction.
-	res, err = c.EstimatesAPI.RequestETD("mcar", "", "S")
+	res, err = client.RequestETD("mcar", "", "S")
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -152,14 +152,14 @@ func ExampleEstimatesAPI() {
 }
 
 func ExampleSchedulesAPI() {
-	c := new(bart.Client)
+	client := bart.NewClient(nil)
 	var res interface{}
 	var err error
 
 	// Use the quick planner to request arrival from Embarcadero to Coliseum
 	// station, at current date, arriving at 6:30pm with 3 trips, before &
 	// after.
-	res, err = c.SchedulesAPI.RequestArrivals(bart.TripParams{
+	res, err = client.RequestArrivals(bart.TripParams{
 		Orig:   "embr",
 		Dest:   "cols",
 		Time:   "6:30pm",
@@ -174,7 +174,7 @@ func ExampleSchedulesAPI() {
 	fmt.Printf("%T\n", res)
 
 	// Get currently available schedules.
-	res, err = c.RequestAvailableSchedules()
+	res, err = client.RequestAvailableSchedules()
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -183,7 +183,7 @@ func ExampleSchedulesAPI() {
 	// Use the quick planner to request departure from SF airport to Castro
 	// Valley station, at current date, departing now with 2 trips, before &
 	// after.
-	res, err = c.RequestDepartures(bart.TripParams{
+	res, err = client.RequestDepartures(bart.TripParams{
 		Orig:   "sfia",
 		Dest:   "cast",
 		Time:   "",
@@ -198,35 +198,35 @@ func ExampleSchedulesAPI() {
 	fmt.Printf("%T\n", res)
 
 	// Get info on upcoming BART holidays and what schedules run on those days.
-	res, err = c.RequestHolidaySchedules()
+	res, err = client.RequestHolidaySchedules()
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Request schedule for route 12, on a Saturday.
-	res, err = c.RequestRouteSchedules(12, "sa", "", true)
+	res, err = client.RequestRouteSchedules(12, "sa", "", true)
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get special schedule notices in effect.
-	res, err = c.RequestSpecialSchedules()
+	res, err = client.RequestSpecialSchedules()
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get a station's schedules for the current date.
-	res, err = c.RequestStationSchedules("mcar", "")
+	res, err = client.RequestStationSchedules("mcar", "")
 	if err != nil {
 		fmt.Println(err)
 	}
 	fmt.Printf("%T\n", res)
 
 	// Get a station's schedules for specific date..
-	res, err = c.RequestStationSchedules("glen", "8/14/2018")
+	res, err = client.RequestStationSchedules("glen", "8/14/2018")
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/routes.go
+++ b/routes.go
@@ -4,7 +4,16 @@ import "net/url"
 
 // RoutesAPI is a namespace for route information requests to routes at
 // /route.aspx. See official docs at https://api.bart.gov/docs/route/.
-type RoutesAPI struct{}
+type RoutesAPI struct {
+	conf *Config
+}
+
+func (a *RoutesAPI) clientConf() *Config {
+	if a != nil && a.conf != nil {
+		return a.conf
+	}
+	return defaultClientConf
+}
 
 // RequestRoutesInfo requests detailed information for all routes. You probably
 // want to request the current schedule on the current date, so pass in "" for
@@ -18,6 +27,7 @@ func (a *RoutesAPI) RequestRoutesInfo(date string) (res RoutesInfoResponse, err 
 	}
 
 	err = requestAPI(
+		a,
 		"/route.aspx",
 		"routeinfo",
 		&params,
@@ -63,6 +73,7 @@ func (a *RoutesAPI) RequestRoutes(date string) (res RoutesResponse, err error) {
 	}
 
 	err = requestAPI(
+		a,
 		"/route.aspx",
 		"routes",
 		&params,

--- a/schedules.go
+++ b/schedules.go
@@ -8,7 +8,16 @@ import (
 
 // SchedulesAPI is a namespace for schedule information requests to routes at
 // /sched.aspx. See official docs at https://api.bart.gov/docs/sched/.
-type SchedulesAPI struct{}
+type SchedulesAPI struct {
+	conf *Config
+}
+
+func (a *SchedulesAPI) clientConf() *Config {
+	if a != nil && a.conf != nil {
+		return a.conf
+	}
+	return defaultClientConf
+}
 
 // RequestArrivals requests a trip plan based on arriving by the specified time.
 // Inputs are specified in the TripParams type. See that type's documentation
@@ -16,6 +25,7 @@ type SchedulesAPI struct{}
 // https://api.bart.gov/docs/sched/arrive.aspx.
 func (a *SchedulesAPI) RequestArrivals(p TripParams) (res TripsResponse, err error) {
 	err = requestAPI(
+		a,
 		"/sched.aspx",
 		"arrive",
 		p.toURLValues(),
@@ -31,6 +41,7 @@ func (a *SchedulesAPI) RequestArrivals(p TripParams) (res TripsResponse, err err
 // https://api.bart.gov/docs/sched/depart.aspx.
 func (a *SchedulesAPI) RequestDepartures(p TripParams) (res TripsResponse, err error) {
 	err = requestAPI(
+		a,
 		"/sched.aspx",
 		"depart",
 		p.toURLValues(),
@@ -87,6 +98,7 @@ type OrigDestTimeData struct {
 // https://api.bart.gov/docs/sched/holiday.aspx.
 func (a *SchedulesAPI) RequestHolidaySchedules() (res HolidaySchedulesResponse, err error) {
 	err = requestAPI(
+		a,
 		"/sched.aspx",
 		"holiday",
 		nil,
@@ -114,6 +126,7 @@ type HolidaySchedulesResponse struct {
 // schedules. See official docs at https://api.bart.gov/docs/sched/scheds.aspx.
 func (a *SchedulesAPI) RequestAvailableSchedules() (res AvailableSchedulesResponse, err error) {
 	err = requestAPI(
+		a,
 		"/sched.aspx",
 		"scheds",
 		nil,
@@ -141,6 +154,7 @@ type AvailableSchedulesResponse struct {
 // https://api.bart.gov/docs/sched/special.aspx.
 func (a *SchedulesAPI) RequestSpecialSchedules() (res SpecialSchedulesResponse, err error) {
 	err = requestAPI(
+		a,
 		"/sched.aspx",
 		"special",
 		nil,
@@ -206,6 +220,7 @@ func (a *SchedulesAPI) RequestStationSchedules(orig, date string) (res StationSc
 	}
 
 	err = requestAPI(
+		a,
 		"/sched.aspx",
 		"stnsched",
 		&params,
@@ -263,6 +278,7 @@ func (a *SchedulesAPI) RequestRouteSchedules(
 	}
 
 	err = requestAPI(
+		a,
 		"/sched.aspx",
 		"routesched",
 		&params,

--- a/schedules_test.go
+++ b/schedules_test.go
@@ -42,13 +42,11 @@ func TestSpecialSchedules(t *testing.T) {
 				panic(err)
 			}
 		}))
-		originalBaseURL := baseURL
-		baseURL = server.URL
+		client := NewClient(nil)
+		client.conf.baseURL = server.URL
 		defer func() {
 			server.Close()
-			baseURL = originalBaseURL
 		}()
-		client := new(Client)
 		_, err := client.RequestSpecialSchedules()
 		if err != nil {
 			t.Errorf(err.Error())
@@ -104,13 +102,11 @@ func TestSpecialSchedules(t *testing.T) {
 				panic(err)
 			}
 		}))
-		originalBaseURL := baseURL
-		baseURL = server.URL
+		client := NewClient(nil)
+		client.conf.baseURL = server.URL
 		defer func() {
 			server.Close()
-			baseURL = originalBaseURL
 		}()
-		client := new(Client)
 		out, err := client.RequestSpecialSchedules()
 		if err != nil {
 			t.Errorf(err.Error())

--- a/stations.go
+++ b/stations.go
@@ -4,7 +4,16 @@ import "net/url"
 
 // StationsAPI is a namespace for stations information requests to routes at
 // /stn.aspx. See official docs at https://api.bart.gov/docs/stn/.
-type StationsAPI struct{}
+type StationsAPI struct {
+	conf *Config
+}
+
+func (a *StationsAPI) clientConf() *Config {
+	if a != nil && a.conf != nil {
+		return a.conf
+	}
+	return defaultClientConf
+}
 
 // RequestStationAccess requests detailed information how to access the
 // specified station as well as information about the neighborhood around the
@@ -15,6 +24,7 @@ func (a *StationsAPI) RequestStationAccess(orig string) (res StationAccessRespon
 	params.Set("orig", orig)
 
 	err = requestAPI(
+		a,
 		"/stn.aspx",
 		"stnaccess",
 		&params,
@@ -57,6 +67,7 @@ func (a *StationsAPI) RequestStationInfo(orig string) (res StationInfoResponse, 
 	params.Set("orig", orig)
 
 	err = requestAPI(
+		a,
 		"/stn.aspx",
 		"stninfo",
 		&params,
@@ -101,6 +112,7 @@ type StationInfoResponse struct {
 // at https://api.bart.gov/docs/stn/stns.aspx.
 func (a *StationsAPI) RequestStations() (res StationsResponse, err error) {
 	err = requestAPI(
+		a,
 		"/stn.aspx",
 		"stns",
 		nil,


### PR DESCRIPTION
Gives user more control over the `Client` such as: specifying `http.Client`
settings and BART API key. Export the default API Key for documentation purposes.

closes #1 

#### features

- specify optional registered API key w/ `Config` type
- add NewClient func

#### fixes

- configure `http.Client` (also w/ `Config` type)

#### tests

- check compatibility of previously-documented examples
- add, update testable examples

#### docs

- update godoc